### PR TITLE
Add Terraform sample setup for Apps Script GCP backend

### DIFF
--- a/empower-your-google-workspace-documents-with-apps-script/README.md
+++ b/empower-your-google-workspace-documents-with-apps-script/README.md
@@ -1,3 +1,3 @@
 # Empower your Google Workspace documents with Apps Script - Sample scripts
 
-This folder contains the two scripts we have described in our LinkedIn article `Empower your Google Workspace documents with Apps Script`.
+This folder contains the two scripts we have described in our LinkedIn article [`Empower your Google Workspace documents with Apps Script`](https://www.linkedin.com/pulse/empower-your-google-workspace-documents-apps-script-shiftavenue-4phcc).

--- a/use-github-to-fully-manage-your-apps-script-development/README.md
+++ b/use-github-to-fully-manage-your-apps-script-development/README.md
@@ -1,0 +1,3 @@
+# Use Git(Hub) to fully manage your Apps Script development - GCP Terraform setup
+
+This folder contains the GCP backend project setup in Terraform (excluding the OAuth consent screen) we have described in our LinkedIn article [`Use Git(Hub) to fully manage your Apps Script development`](insertlink).

--- a/use-github-to-fully-manage-your-apps-script-development/config.auto.tfvars
+++ b/use-github-to-fully-manage-your-apps-script-development/config.auto.tfvars
@@ -1,0 +1,7 @@
+project_id = "my-gcp-project"
+gcp_project_services = [
+  "script.googleapis.com",
+  "iamcredentials.googleapis.com",
+  "iam.googleapis.com", # Will be auto-enabled when activating iamcredentials.googleapis.com, however let's specify it anyway
+]
+github_repository = "my-org/my-gh-repository"

--- a/use-github-to-fully-manage-your-apps-script-development/iam.tf
+++ b/use-github-to-fully-manage-your-apps-script-development/iam.tf
@@ -1,0 +1,31 @@
+locals {
+  # The service user used for creating the Apps Script project
+  # Will be impersonated in GitHub Actions workflows for script deployment
+  service_user_name = "apps-script-auto-user"
+
+  # The GCP service account used for Workload Identity Federation, make sure to configure domain-wide delegation for this account
+  service_account_name = "apps-script-auto"
+}
+
+# Service Account used for automation scripts
+resource "google_service_account" "main" {
+  account_id   = local.service_account_name
+  display_name = "Service account to be used to interact with Apps Script REST API"
+}
+
+# OAuth Config Editor role for service user automation account to be able to use GCP project as Apps Script backend project
+resource "google_project_iam_member" "oauth_config_editor" {
+  project = var.project_id
+  role    = "roles/oauthconfig.editor"
+  member  = "user:${local.service_user_name}@my-company.com"
+}
+
+# Service Account Token creator role needed for external identity (the GitHub repository)
+# so that the impersonation in GitHub Actions workflows work
+resource "google_service_account_iam_binding" "token_creator" {
+  service_account_id = google_service_account.main.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+  members = [
+    "principalSet://iam.googleapis.com/${module.gh_oidc.pool_name}/attribute.repository/${var.github_repository}"
+  ]
+}

--- a/use-github-to-fully-manage-your-apps-script-development/project.tf
+++ b/use-github-to-fully-manage-your-apps-script-development/project.tf
@@ -1,0 +1,17 @@
+/*
+ * Baseline project setup
+ */
+
+# Project can also be created via Terraform, in this example it has been created already
+data "google_project" "main" {
+  project_id = var.project_id
+}
+
+# All enabled GCP APIs
+resource "google_project_service" "main" {
+  for_each = var.gcp_project_services
+  project  = var.project_id
+  service  = each.value
+
+  disable_dependent_services = true
+}

--- a/use-github-to-fully-manage-your-apps-script-development/variables.tf
+++ b/use-github-to-fully-manage-your-apps-script-development/variables.tf
@@ -1,0 +1,14 @@
+variable "project_id" {
+  description = "The GCP project ID"
+  type        = string
+}
+
+variable "gcp_project_services" {
+  description = "The services/APIs enabled in the GCP project"
+  type        = set(string)
+}
+
+variable "github_repository" {
+  description = "The GitHub repository containing the Apps Script code"
+  type        = string
+}

--- a/use-github-to-fully-manage-your-apps-script-development/versions.tf
+++ b/use-github-to-fully-manage-your-apps-script-development/versions.tf
@@ -1,0 +1,14 @@
+# Provider and terraform config
+terraform {
+  required_version = "~>1.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~>4.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~>4.0"
+    }
+  }
+}

--- a/use-github-to-fully-manage-your-apps-script-development/workload_identity.tf
+++ b/use-github-to-fully-manage-your-apps-script-development/workload_identity.tf
@@ -1,0 +1,17 @@
+/*
+ * Workload Identity setup used for authenticating in GitHub Actions workflows
+ */
+
+module "gh_oidc" {
+  source      = "terraform-google-modules/github-actions-runners/google//modules/gh-oidc"
+  version     = "3.1.2"
+  project_id  = data.google_project.main.number
+  pool_id     = "gh-actions-wif-pool"
+  provider_id = "github"
+  sa_mapping = {
+    "apps-script-auto" = {
+      sa_name   = "projects/${var.project_id}/serviceAccounts/${google_service_account.main.email}"
+      attribute = "attribute.repository/${var.github_repository}"
+    }
+  }
+}


### PR DESCRIPTION
Adds the sample Terraform code to provision the necessary GCP infrastructure described in our article `Use Git(Hub) to fully manage your Apps Script development` (excluding the OAuth consent screen, as it cannot be created programmatically).